### PR TITLE
Register uuid.UUID msgpack ext codec in work package

### DIFF
--- a/uuid_ext.go
+++ b/uuid_ext.go
@@ -1,0 +1,58 @@
+package work
+
+import (
+	"reflect"
+
+	"github.com/google/uuid"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// uuidExtID is the msgpack extension id used to encode uuid.UUID values inside
+// job payloads. It is 3 for historical reasons: the polytomic application
+// previously registered this codec from its own package, and jobs already
+// persisted in Redis encode UUIDs as fixext16 with this type id. Changing it
+// would make those queued jobs undecodable.
+const uuidExtID = 3
+
+// The msgpack ext codec for uuid.UUID is registered here, in the work package,
+// because this is the package that owns (Un)MarshalPayload and the underlying
+// marshal/unmarshal helpers. msgpack's ext registry is process-global, so the
+// encoder and decoder must be registered before any payload containing a
+// uuid.UUID is (de)serialized.
+//
+// Previously this registration lived only in the application's top-level `app`
+// package as an init() side effect. Because the job enqueue paths
+// (e.g. sync/executor) do not import `app`, any binary built without it -- most
+// notably per-package test binaries -- had no encoder registered and serialized
+// uuid.UUID ([16]byte) as msgpack bin8 (code c4) instead of the ext type
+// (fixext16, code d8). The worker, which does register the ext decoder, then
+// could not decode those payloads and failed with
+// "invalid job payload: msgpack: invalid code=c4 decoding ext len", wedging the
+// single-slot dequeuer on the undecodable job.
+//
+// Registering on the work package guarantees encode/decode symmetry: a payload
+// cannot be (un)marshaled without importing this package, and importing it runs
+// this init().
+func uuidEncoder(e *msgpack.Encoder, v reflect.Value) ([]byte, error) {
+	uu := v.Interface().(uuid.UUID)
+	return uu.MarshalBinary()
+}
+
+func uuidDecoder(d *msgpack.Decoder, v reflect.Value, extLen int) error {
+	b := make([]byte, extLen)
+	if err := d.ReadFull(b); err != nil {
+		return err
+	}
+	uu, err := uuid.FromBytes(b)
+	if err != nil {
+		return err
+	}
+	*v.Addr().Interface().(*uuid.UUID) = uu
+
+	return nil
+}
+
+func init() {
+	msgpack.RegisterExtDecoder(uuidExtID, uuid.UUID{}, uuidDecoder)
+	msgpack.RegisterExtEncoder(uuidExtID, uuid.UUID{}, uuidEncoder)
+}

--- a/uuid_ext_test.go
+++ b/uuid_ext_test.go
@@ -1,0 +1,36 @@
+package work
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUUIDPayloadUsesExtEncoding guards against the regression where uuid.UUID
+// fields were serialized as msgpack bin8 (code 0xc4) instead of the registered
+// fixext16 ext type (code 0xd8). A 0xc4-encoded payload is undecodable by a
+// process that has the ext decoder registered, and poisons the dequeuer.
+func TestUUIDPayloadUsesExtEncoding(t *testing.T) {
+	type payload struct {
+		ID uuid.UUID `msgpack:"id"`
+	}
+	id := uuid.MustParse("f32a93af-3d28-4df9-bb16-81634cfcf71f")
+
+	job := NewJob()
+	require.NoError(t, job.MarshalPayload(payload{ID: id}))
+
+	// fixext16 framing for ext type 3: 0xd8 0x03 followed by the 16 raw bytes.
+	idBytes, _ := id.MarshalBinary()
+	wantFraming := append([]byte{0xd8, uuidExtID}, idBytes...)
+	require.True(t, bytes.Contains(job.Payload, wantFraming),
+		"expected fixext16 (0xd8 0x03) UUID framing in payload, got % x", job.Payload)
+	require.NotContains(t, string(job.Payload), string([]byte{0xc4, 0x10}),
+		"payload must not contain bin8 (0xc4 0x10) UUID framing")
+
+	// And it must round-trip back to the same UUID.
+	var got payload
+	require.NoError(t, job.UnmarshalPayload(&got))
+	require.Equal(t, id, got.ID)
+}


### PR DESCRIPTION
Job payloads containing uuid.UUID fields rely on a process-global msgpack extension codec (ext type 3, fixext16) to encode/decode UUIDs. That codec was previously registered only as an init() side effect of the polytomic application's top-level `app` package. Enqueue paths (e.g. sync/executor) do not import `app`, so any binary built without it -- notably per-package test binaries -- had no encoder registered and serialized uuid.UUID as msgpack bin8 (code c4) instead of the ext type (code d8). A worker that did register the decoder then could not decode those payloads, failing with "invalid job payload: msgpack: invalid code=c4 decoding ext len" and wedging the single-slot dequeuer on the undecodable job.

Register the codec here, alongside the (Un)MarshalPayload helpers that depend on it. A payload cannot be (un)marshaled without importing this package, so its init() always runs, guaranteeing encode/decode symmetry in every binary.