### PR TITLE
Add Requeuer hook preferred by the retry path

### DIFF
--- a/job.go
+++ b/job.go
@@ -228,6 +228,20 @@ type Queue interface {
 	Dequeuer
 }
 
+// Requeuer is an optional interface a Queue may implement to express the
+// framework's retry move ("this job failed, put it back") distinctly from
+// Enqueue ("add a new job"). When a Queue implements Requeuer, the worker's
+// retry path calls Requeue with the computed backoff instead of Enqueue.
+//
+// RedisQueue does not implement Requeuer, so its retry behavior is unchanged
+// (Enqueue with a bumped score). A custom Queue whose Enqueue and "retry a
+// failed in-flight job" are different operations — for example one that keeps
+// waiting and in-flight jobs in separate structures — implements Requeuer so
+// the retry path is unambiguous.
+type Requeuer interface {
+	Requeue(job *Job, backoff time.Duration, opt *EnqueueOptions) error
+}
+
 // BulkEnqueuer enqueues jobs in a batch.
 type BulkEnqueuer interface {
 	BulkEnqueue([]*Job, *EnqueueOptions) error

--- a/worker.go
+++ b/worker.go
@@ -384,11 +384,24 @@ func retry(queue Queue, backoff BackoffFunc) HandleMiddleware {
 				job.LastError = err.Error()
 				job.UpdatedAt = now
 
-				job.EnqueuedAt = now.Add(backoff(job, opt))
-				queue.Enqueue(job, &EnqueueOptions{
-					Namespace: opt.Namespace,
-					QueueID:   opt.QueueID,
-				})
+				d := backoff(job, opt)
+				job.EnqueuedAt = now.Add(d)
+				// Prefer the Requeuer hook when the queue implements it, so a
+				// queue whose "retry a failed job" differs from "enqueue a new
+				// job" gets the right operation with the computed backoff.
+				// RedisQueue does not implement Requeuer, so it keeps using
+				// Enqueue and is byte-identical.
+				if r, ok := queue.(Requeuer); ok {
+					r.Requeue(job, d, &EnqueueOptions{
+						Namespace: opt.Namespace,
+						QueueID:   opt.QueueID,
+					})
+				} else {
+					queue.Enqueue(job, &EnqueueOptions{
+						Namespace: opt.Namespace,
+						QueueID:   opt.QueueID,
+					})
+				}
 				return err
 			}
 			return nil

--- a/worker.go
+++ b/worker.go
@@ -385,18 +385,20 @@ func retry(queue Queue, backoff BackoffFunc) HandleMiddleware {
 				job.UpdatedAt = now
 
 				d := backoff(job, opt)
-				job.EnqueuedAt = now.Add(d)
 				// Prefer the Requeuer hook when the queue implements it, so a
 				// queue whose "retry a failed job" differs from "enqueue a new
 				// job" gets the right operation with the computed backoff.
 				// RedisQueue does not implement Requeuer, so it keeps using
 				// Enqueue and is byte-identical.
 				if r, ok := queue.(Requeuer); ok {
+					// Requeue carries the backoff explicitly; EnqueuedAt (the
+					// Enqueue path's score) is left untouched.
 					r.Requeue(job, d, &EnqueueOptions{
 						Namespace: opt.Namespace,
 						QueueID:   opt.QueueID,
 					})
 				} else {
+					job.EnqueuedAt = now.Add(d)
 					queue.Enqueue(job, &EnqueueOptions{
 						Namespace: opt.Namespace,
 						QueueID:   opt.QueueID,

--- a/worker.go
+++ b/worker.go
@@ -385,20 +385,23 @@ func retry(queue Queue, backoff BackoffFunc) HandleMiddleware {
 				job.UpdatedAt = now
 
 				d := backoff(job, opt)
+				// EnqueuedAt is the job's next-execution time — RedisQueue's
+				// score, and read by status reporting — so keep it consistent
+				// with the delay on both paths. The Requeuer additionally
+				// receives d explicitly as its scheduling instruction.
+				job.EnqueuedAt = now.Add(d)
 				// Prefer the Requeuer hook when the queue implements it, so a
 				// queue whose "retry a failed job" differs from "enqueue a new
 				// job" gets the right operation with the computed backoff.
 				// RedisQueue does not implement Requeuer, so it keeps using
 				// Enqueue and is byte-identical.
 				if r, ok := queue.(Requeuer); ok {
-					// Requeue carries the backoff explicitly; EnqueuedAt (the
-					// Enqueue path's score) is left untouched. Surface a Requeue
-					// failure instead of the handler error: the latter is a
-					// *wrappedHandlerError that Worker.start suppresses, so a
-					// Requeue infrastructure failure — which can strand the job in
-					// the in-flight structure until its lease lapses — would go
-					// unreported. This error is not a wrappedHandlerError, so it
-					// reaches the worker's ErrorFunc.
+					// Surface a Requeue failure instead of the handler error: the
+					// latter is a *wrappedHandlerError that Worker.start
+					// suppresses, so a Requeue infrastructure failure — which can
+					// strand the job in the in-flight structure until its lease
+					// lapses — would go unreported. This error is not a
+					// wrappedHandlerError, so it reaches the worker's ErrorFunc.
 					if reqErr := r.Requeue(job, d, &EnqueueOptions{
 						Namespace: opt.Namespace,
 						QueueID:   opt.QueueID,
@@ -406,7 +409,6 @@ func retry(queue Queue, backoff BackoffFunc) HandleMiddleware {
 						return fmt.Errorf("work: requeue failed for job %s (handler error: %v): %w", job.ID, err, reqErr)
 					}
 				} else {
-					job.EnqueuedAt = now.Add(d)
 					queue.Enqueue(job, &EnqueueOptions{
 						Namespace: opt.Namespace,
 						QueueID:   opt.QueueID,

--- a/worker.go
+++ b/worker.go
@@ -392,11 +392,19 @@ func retry(queue Queue, backoff BackoffFunc) HandleMiddleware {
 				// Enqueue and is byte-identical.
 				if r, ok := queue.(Requeuer); ok {
 					// Requeue carries the backoff explicitly; EnqueuedAt (the
-					// Enqueue path's score) is left untouched.
-					r.Requeue(job, d, &EnqueueOptions{
+					// Enqueue path's score) is left untouched. Surface a Requeue
+					// failure instead of the handler error: the latter is a
+					// *wrappedHandlerError that Worker.start suppresses, so a
+					// Requeue infrastructure failure — which can strand the job in
+					// the in-flight structure until its lease lapses — would go
+					// unreported. This error is not a wrappedHandlerError, so it
+					// reaches the worker's ErrorFunc.
+					if reqErr := r.Requeue(job, d, &EnqueueOptions{
 						Namespace: opt.Namespace,
 						QueueID:   opt.QueueID,
-					})
+					}); reqErr != nil {
+						return fmt.Errorf("work: requeue failed for job %s (handler error: %v): %w", job.ID, err, reqErr)
+					}
 				} else {
 					job.EnqueuedAt = now.Add(d)
 					queue.Enqueue(job, &EnqueueOptions{

--- a/worker_test.go
+++ b/worker_test.go
@@ -530,7 +530,6 @@ func TestRetryPrefersRequeuer(t *testing.T) {
 	job := NewJob()
 	opt := &DequeueOptions{Namespace: "{ns}", QueueID: "q1", InvisibleSec: 10}
 
-	enqueuedAtBefore := job.EnqueuedAt
 	h := retrier(func(*Job, *DequeueOptions) error { return fmt.Errorf("boom") })
 	err := h(job, opt)
 	require.Error(t, err)
@@ -539,9 +538,11 @@ func TestRetryPrefersRequeuer(t *testing.T) {
 	require.Equal(t, 1, q.requeued)
 	require.Equal(t, 0, q.enqueued)
 	require.EqualValues(t, 1, job.Retries)
-	// Requeue receives the backoff explicitly, so EnqueuedAt (the Enqueue
-	// path's score) is left untouched on this branch.
-	require.Equal(t, enqueuedAtBefore, job.EnqueuedAt)
+	// EnqueuedAt is advanced to the next-execution time by the same backoff
+	// that was passed to Requeue, so job metadata and the scheduling
+	// instruction agree.
+	require.Positive(t, q.lastBackoff)
+	require.Equal(t, job.UpdatedAt.Add(q.lastBackoff), job.EnqueuedAt)
 }
 
 func TestRetryRequeueErrorSurfaced(t *testing.T) {

--- a/worker_test.go
+++ b/worker_test.go
@@ -498,3 +498,58 @@ func TestRetry(t *testing.T) {
 		require.True(t, delays[i] > 1)
 	}
 }
+
+// fakeRequeuerQueue is a Queue that also implements Requeuer; it records which
+// path the retry middleware takes.
+type fakeRequeuerQueue struct {
+	enqueued    int
+	requeued    int
+	lastBackoff time.Duration
+}
+
+func (q *fakeRequeuerQueue) Enqueue(*Job, *EnqueueOptions) error   { q.enqueued++; return nil }
+func (q *fakeRequeuerQueue) Dequeue(*DequeueOptions) (*Job, error) { return nil, ErrEmptyQueue }
+func (q *fakeRequeuerQueue) Ack(*Job, *AckOptions) error           { return nil }
+func (q *fakeRequeuerQueue) Requeue(job *Job, backoff time.Duration, opt *EnqueueOptions) error {
+	q.requeued++
+	q.lastBackoff = backoff
+	return nil
+}
+
+// fakePlainQueue is a Queue that does NOT implement Requeuer.
+type fakePlainQueue struct{ enqueued int }
+
+func (q *fakePlainQueue) Enqueue(*Job, *EnqueueOptions) error   { q.enqueued++; return nil }
+func (q *fakePlainQueue) Dequeue(*DequeueOptions) (*Job, error) { return nil, ErrEmptyQueue }
+func (q *fakePlainQueue) Ack(*Job, *AckOptions) error           { return nil }
+
+func TestRetryPrefersRequeuer(t *testing.T) {
+	q := &fakeRequeuerQueue{}
+	retrier := retry(q, defaultBackoff())
+	job := NewJob()
+	opt := &DequeueOptions{Namespace: "{ns}", QueueID: "q1", InvisibleSec: 10}
+
+	h := retrier(func(*Job, *DequeueOptions) error { return fmt.Errorf("boom") })
+	err := h(job, opt)
+	require.Error(t, err)
+
+	// The retry move went through Requeue (with a backoff), not Enqueue.
+	require.Equal(t, 1, q.requeued)
+	require.Equal(t, 0, q.enqueued)
+	require.EqualValues(t, 1, job.Retries)
+}
+
+func TestRetryFallsBackToEnqueue(t *testing.T) {
+	q := &fakePlainQueue{}
+	retrier := retry(q, defaultBackoff())
+	job := NewJob()
+	opt := &DequeueOptions{Namespace: "{ns}", QueueID: "q1", InvisibleSec: 10}
+
+	h := retrier(func(*Job, *DequeueOptions) error { return fmt.Errorf("boom") })
+	err := h(job, opt)
+	require.Error(t, err)
+
+	// A queue without Requeuer keeps using Enqueue — byte-identical behavior.
+	require.Equal(t, 1, q.enqueued)
+	require.EqualValues(t, 1, job.Retries)
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -505,6 +505,7 @@ type fakeRequeuerQueue struct {
 	enqueued    int
 	requeued    int
 	lastBackoff time.Duration
+	requeueErr  error
 }
 
 func (q *fakeRequeuerQueue) Enqueue(*Job, *EnqueueOptions) error   { q.enqueued++; return nil }
@@ -513,7 +514,7 @@ func (q *fakeRequeuerQueue) Ack(*Job, *AckOptions) error           { return nil 
 func (q *fakeRequeuerQueue) Requeue(job *Job, backoff time.Duration, opt *EnqueueOptions) error {
 	q.requeued++
 	q.lastBackoff = backoff
-	return nil
+	return q.requeueErr
 }
 
 // fakePlainQueue is a Queue that does NOT implement Requeuer.
@@ -541,6 +542,27 @@ func TestRetryPrefersRequeuer(t *testing.T) {
 	// Requeue receives the backoff explicitly, so EnqueuedAt (the Enqueue
 	// path's score) is left untouched on this branch.
 	require.Equal(t, enqueuedAtBefore, job.EnqueuedAt)
+}
+
+func TestRetryRequeueErrorSurfaced(t *testing.T) {
+	reqErr := errors.New("redis unavailable")
+	q := &fakeRequeuerQueue{requeueErr: reqErr}
+
+	// Build the chain the worker builds: wrapHandlerError sits inside retry, so
+	// a handler error becomes a *wrappedHandlerError that Worker.start
+	// suppresses. A Requeue failure must escape that suppression.
+	inner := wrapHandlerError(func(*Job, *DequeueOptions) error { return fmt.Errorf("boom") })
+	h := retry(q, defaultBackoff())(inner)
+	opt := &DequeueOptions{Namespace: "{ns}", QueueID: "q1", InvisibleSec: 10}
+
+	err := h(NewJob(), opt)
+	require.Error(t, err)
+	// The requeue failure is reported (errors.Is finds it)...
+	require.ErrorIs(t, err, reqErr)
+	// ...and it is NOT a wrappedHandlerError, so Worker.start's suppression
+	// branch does not swallow it.
+	var whe *wrappedHandlerError
+	require.False(t, errors.As(err, &whe), "requeue failure must not be suppressed as a handler error")
 }
 
 func TestRetryFallsBackToEnqueue(t *testing.T) {

--- a/worker_test.go
+++ b/worker_test.go
@@ -529,6 +529,7 @@ func TestRetryPrefersRequeuer(t *testing.T) {
 	job := NewJob()
 	opt := &DequeueOptions{Namespace: "{ns}", QueueID: "q1", InvisibleSec: 10}
 
+	enqueuedAtBefore := job.EnqueuedAt
 	h := retrier(func(*Job, *DequeueOptions) error { return fmt.Errorf("boom") })
 	err := h(job, opt)
 	require.Error(t, err)
@@ -537,6 +538,9 @@ func TestRetryPrefersRequeuer(t *testing.T) {
 	require.Equal(t, 1, q.requeued)
 	require.Equal(t, 0, q.enqueued)
 	require.EqualValues(t, 1, job.Retries)
+	// Requeue receives the backoff explicitly, so EnqueuedAt (the Enqueue
+	// path's score) is left untouched on this branch.
+	require.Equal(t, enqueuedAtBefore, job.EnqueuedAt)
 }
 
 func TestRetryFallsBackToEnqueue(t *testing.T) {


### PR DESCRIPTION
Add an optional Requeuer interface a Queue may implement to express the
retry move ("this failed, put it back") distinctly from Enqueue ("add a
new job"). The worker retry path now prefers Requeue with the computed
backoff when the queue implements it, and falls back to Enqueue
otherwise. RedisQueue does not implement Requeuer, so its behavior is
unchanged.

This lets a queue whose waiting and in-flight jobs live in separate
structures restore a failed in-flight job to its position instead of
enqueuing a duplicate.